### PR TITLE
fix: add try/cath

### DIFF
--- a/src/android/BackgroundMode.java
+++ b/src/android/BackgroundMode.java
@@ -278,14 +278,17 @@ public class BackgroundMode extends CordovaPlugin {
     private void stopService()
     {
         Activity context = cordova.getActivity();
-        Intent intent    = new Intent(context, ForegroundService.class);
+        Intent intent = new Intent(context, ForegroundService.class);
 
         if (!isBind) return;
 
-        fireEvent(Event.DEACTIVATE, null);
-        context.unbindService(connection);
-        context.stopService(intent);
-
+        try{
+            fireEvent(Event.DEACTIVATE, null);
+            context.unbindService(connection);
+            context.stopService(intent);
+        }catch(IllegalStateException e){
+            fireEvent(Event.FAILURE, String.format("'%s'", e.getMessage()));
+        }
         isBind = false;
     }
 


### PR DESCRIPTION
Use try/catch to deal with the problem of an error when reading stopService when the service has not been started in the application.

refs: https://developer.android.com/reference/android/content/Context#stopService(android.content.Intent)