### PR TITLE
add PendingIntent.FLAG_IMMUTABLE

### DIFF
--- a/src/android/ForegroundService.java
+++ b/src/android/ForegroundService.java
@@ -241,7 +241,7 @@ public class ForegroundService extends Service {
             intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP | Intent.FLAG_ACTIVITY_SINGLE_TOP);
             PendingIntent contentIntent = PendingIntent.getActivity(
                     context, NOTIFICATION_ID, intent,
-                    PendingIntent.FLAG_UPDATE_CURRENT);
+                    PendingIntent.FLAG_IMMUTABLE);
 
 
             notification.setContentIntent(contentIntent);


### PR DESCRIPTION
fix it.

>Targeting S+ (version 31 and above) requires that one of FLAG_IMMUTABLE or FLAG_MUTABLE be specified when creating a PendingIntent.